### PR TITLE
Add '.el' to the header line

### DIFF
--- a/emacs-conflict.el
+++ b/emacs-conflict.el
@@ -1,4 +1,4 @@
-;;; emacs-conflict --- quickly find and resolve conflicts in external tools like Syncthing  -*- lexical-binding:t -*-
+;;; emacs-conflict.el --- quickly find and resolve conflicts in external tools like Syncthing  -*- lexical-binding:t -*-
 
 ;; Copyright (C) 2019 Pierre Penninckx
 


### PR DESCRIPTION
I tried to install this with Quelpa:

```
(quelpa '(emacs-conflict :fetcher github :repo "ibizaman/emacs-conflict"))
```

But it gives me:

```
Debugger entered--Lisp error: (error "Package lacks a file header")
```

As it turns out, this error is from the `(package-buffer-info)` function from `package.el`, because it expects `emacs-conflict ---` in the header line to be `emacs-conflict.el ---`. Just added that and it works.