### PR TITLE
Implement renaming to/from conflict.

### DIFF
--- a/emacs-conflict-test.el
+++ b/emacs-conflict-test.el
@@ -40,6 +40,21 @@
 	   "tests/conflicts/two.el"
 	   "tests/conflicts/three.el"))))
 
+(ert-deftest emacs-conflict-get-conflict-file ()
+  "Tests finding back the normal file from the conflict file."
+  (should
+   (equal
+    (mapcar (lambda (args) (let ((filename (nth 0 args))
+                            (type (nth 1 args)))
+                        (catch 'conflict-not-implemented
+                          (emacs-conflict--get-conflict-filename filename type))))
+            '(("tests/conflicts/one.el" "syncthing")
+              ("tests/conflicts/two.el" "nextcloud")
+              ("tests/conflicts/three.el" "pacman")))
+    '("tests/conflicts/one.sync-conflict-.el"
+      "tests/conflicts/two (conflicted copy 2021-05-28 225359).el"
+      "tests/conflicts/three.el.pacnew"))))
+
 (provide 'emacs-conflict-test)
 
 ;;; emacs-conflict-test.el ends here


### PR DESCRIPTION
### Intro
I had made [my own repo](https://github.com/tuh8888/syncthing.el) for fixing syncthing conflicts with ediff. I like your approach much better, but there is one bit of functionality I wanted to carry over, that being converting the current buffer to a conflict.

### Explanation
To explain why I need this, let me describe a use-case I have. I use Orgzly for managing my org files on my phone with Syncthing to move my org files back and forth. Orgzly keeps an internal database for its org state which it syncs to the files on the phone every so often. When it detects that a change has been made in between its database syncs, it gives a warning. The best way I've found to resolve this is to change the name of the associated file on my desktop, allow Syncthing to push that change to my phone, and Orgzly will now think that a new org file has been made and no longer thinks it is out of sync since the old file looks like it was deleted, and creates a new org file of the same name as the original. Finally syncthing will push the new file from my phone to my computer where I can diff it with the renamed version.

From looking around the web, this Orgzly, Syncthing, Emacs setup is pretty common and Orgzly's sync conflicts are annoying to others as well, so maybe this will be helpful to others.

### Changes
The following changes have been made to allow for this:
1. The main new user-exposed function is `emacs-conflict-rename-current-buffer-file-to-sync-conflict` which renames the current file to a conflict of the seleced type (syncthing, nextcloud, etc). The type can be selected via `completing-read` or with a default provided by `emacs-conflict-default-conflict-type`.
2. A function analogous to `emacs-conflict--get-normal-filename` called `emacs-conflict--get-conflict-filename` which converts a filename to a sync-conflict of the provided type.
3. A test for `emacs-conflict--get-conflict-filename`. It fails for now for the "pacman" and "next cloud" cases since I have only provided conversion rules for "syncthing".
4. A  **breaking** change for the config variable `emacs-conflict-find-regexes`. The conversion rules have been added here since it already was delimited by sync type. For the conversion, there is a regexp to find where in the filename the conflict identifying text should go and a function for how to but it there. I've converted it to an alist of alists since there are so many things in this list. There are two other implementations we could do if you don't like that this is a breaking change.
    1. Have the values of `emacs-conflict-find-regexes` be a list of length 4. This would be less clear but keeps it all together.
    2. Split it into a new variable like `emacs-conflict-convert-regexes`.

### Other considerations
1. To make sure the renaming process doesn't mess with other commonly used packages (`projectile` and `recentf`), there's some checks that reference functions that aren't always defined which produces compilation warnings.