### PR TITLE
Optional '.' at file name end, for file names without extensions

### DIFF
--- a/emacs-conflict.el
+++ b/emacs-conflict.el
@@ -58,8 +58,8 @@
   :prefix "emacs-conflict")
 
 (defcustom emacs-conflict-find-regexes
-  '(("syncthing" "\\.sync-conflict-.*\\(\\.\\)" "\\1")
-    ("nextcloud" " (conflicted copy .*)\\(\\.\\)" "\\1")
+  '(("syncthing" "\\.sync-conflict-.*\\(\\.?\\)" "\\1")
+    ("nextcloud" " (conflicted copy .*)\\(\\.?\\)" "\\1")
     ("pacman" "\\(?:\\.\\)pacnew$" ""))
   "Regexes to identify a file as a conflict."
   :type '(alist :key-type string :value-type (list regexp regexp))


### PR DESCRIPTION
The default file name regexps require a `.` in the file name. This doesn't work for me for files which are just named e.g. `zshrc`.